### PR TITLE
fix: Sunken Helmet Data

### DIFF
--- a/src/data/accessories.js
+++ b/src/data/accessories.js
@@ -666,7 +666,7 @@ export const accessories = [
         defense : 153,
         power : 0,
         agility : 0,
-        attackSize : 18,
+        attackSize : 26,
         attackSpeed : 0,
         intensity : 0,
         insanity : 0,


### PR DESCRIPTION
fix helmet to have 26 atk. size as according to caerot
![grafik](https://github.com/BobbyNooby/AOGearBuilder/assets/16324266/35176504-8c61-4bb1-982c-a3133c9cd805)
![grafik](https://github.com/BobbyNooby/AOGearBuilder/assets/16324266/b94c9e07-a475-4f39-b2d7-4942f7f48cce)
